### PR TITLE
fix: undefined option adds to result, if no linterhub:path required

### DIFF
--- a/src/parseSection.js
+++ b/src/parseSection.js
@@ -21,7 +21,9 @@ const options = (section, context, argumentTemplate) => {
 const usage = (section, context, argumentTemplate) => {
     let argument = Object.assign({}, argumentTemplate);
     argument.longName = '';
-    context.options.push(section.match(/file|path/i) ? argument : {});
+    if (section.match(/file|path/i)) {
+        context.options.push(argument);
+    }
 };
 
 const examples = (section, context) => {


### PR DESCRIPTION
Closes #64