### PR TITLE
test: add parsing tests

### DIFF
--- a/test/parsing/files/example.delimiter1.json
+++ b/test/parsing/files/example.delimiter1.json
@@ -1,0 +1,40 @@
+{
+   "$schema": "https://repometric.github.io/linterhub/schema/args.json",
+   "name": "",
+   "type": "object",
+   "allOf": [
+      {
+         "$ref": "#/definitions/arguments"
+      }
+   ],
+   "delimiter": "=",
+   "definitions": {
+      "arguments": {
+         "type": "object",
+         "properties": {
+            "--ignore": {
+               "id": "--ignore",
+               "type": "string",
+               "description": "Additional paths to ignore [Can be set multiple times]",
+               "default": null
+            }
+         }
+      },
+      "section": {
+         "type": "object",
+         "description": "The engine configuration section",
+         "properties": {
+            "name": {
+               "type": "string",
+               "description": "The engine name",
+               "enum": ""
+            },
+            "options": {
+               "type": "object",
+               "description": "The engine configuration",
+               "$ref": "#/definitions/arguments"
+            }
+         }
+      }
+   }
+}

--- a/test/parsing/files/example.delimiter1.txt
+++ b/test/parsing/files/example.delimiter1.txt
@@ -1,0 +1,5 @@
+  Options:
+   --ignore, -i          Additional paths to ignore [Can be set multiple times]
+
+  Examples:
+    $ xo --env=node

--- a/test/parsing/files/example.delimiter2.json
+++ b/test/parsing/files/example.delimiter2.json
@@ -1,0 +1,40 @@
+{
+   "$schema": "https://repometric.github.io/linterhub/schema/args.json",
+   "name": "",
+   "type": "object",
+   "allOf": [
+      {
+         "$ref": "#/definitions/arguments"
+      }
+   ],
+   "delimiter": " ",
+   "definitions": {
+      "arguments": {
+         "type": "object",
+         "properties": {
+            "--ignore": {
+               "id": "--ignore",
+               "type": "string",
+               "description": "Additional paths to ignore [Can be set multiple times]",
+               "default": null
+            }
+         }
+      },
+      "section": {
+         "type": "object",
+         "description": "The engine configuration section",
+         "properties": {
+            "name": {
+               "type": "string",
+               "description": "The engine name",
+               "enum": ""
+            },
+            "options": {
+               "type": "object",
+               "description": "The engine configuration",
+               "$ref": "#/definitions/arguments"
+            }
+         }
+      }
+   }
+}

--- a/test/parsing/files/example.delimiter2.txt
+++ b/test/parsing/files/example.delimiter2.txt
@@ -1,0 +1,5 @@
+  Options:
+   --ignore, -i          Additional paths to ignore [Can be set multiple times]
+
+  Examples:
+    $ xo --env node

--- a/test/parsing/files/example.delimiter3.json
+++ b/test/parsing/files/example.delimiter3.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://repometric.github.io/linterhub/schema/args.json",
+    "name": "",
+    "type": "object",
+    "allOf": [
+        {
+            "$ref": "#/definitions/arguments"
+        }
+    ],
+    "delimiter": "+",
+    "definitions": {
+        "arguments": {
+            "type": "object",
+            "properties": {
+                "--ignore": {
+                    "id": "--ignore",
+                    "type": "string",
+                    "description": "Additional paths to ignore [Can be set multiple times]",
+                    "default": null
+                }
+            }
+        },
+        "section": {
+            "type": "object",
+            "description": "The engine configuration section",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The engine name",
+                    "enum": ""
+                },
+                "options": {
+                    "type": "object",
+                    "description": "The engine configuration",
+                    "$ref": "#/definitions/arguments"
+                }
+            }
+        }
+    }
+}

--- a/test/parsing/files/example.delimiter3.txt
+++ b/test/parsing/files/example.delimiter3.txt
@@ -1,0 +1,5 @@
+  Options:
+   --ignore, -i          Additional paths to ignore [Can be set multiple times]
+
+  Examples:
+    $ xo --env+node

--- a/test/parsing/files/example.no-delimiter.json
+++ b/test/parsing/files/example.no-delimiter.json
@@ -1,0 +1,40 @@
+{
+   "$schema": "https://repometric.github.io/linterhub/schema/args.json",
+   "name": "",
+   "type": "object",
+   "allOf": [
+      {
+         "$ref": "#/definitions/arguments"
+      }
+   ],
+   "delimiter": "=",
+   "definitions": {
+      "arguments": {
+         "type": "object",
+         "properties": {
+            "--ignore": {
+               "id": "--ignore",
+               "type": "string",
+               "description": "Additional paths to ignore [Can be set multiple times]",
+               "default": null
+            }
+         }
+      },
+      "section": {
+         "type": "object",
+         "description": "The engine configuration section",
+         "properties": {
+            "name": {
+               "type": "string",
+               "description": "The engine name",
+               "enum": ""
+            },
+            "options": {
+               "type": "object",
+               "description": "The engine configuration",
+               "$ref": "#/definitions/arguments"
+            }
+         }
+      }
+   }
+}

--- a/test/parsing/files/example.no-delimiter.txt
+++ b/test/parsing/files/example.no-delimiter.txt
@@ -1,0 +1,5 @@
+  Options:
+   --ignore, -i          Additional paths to ignore [Can be set multiple times]
+
+  Examples:
+    $ xo --env-node

--- a/test/parsing/files/full.valid.json
+++ b/test/parsing/files/full.valid.json
@@ -1,0 +1,124 @@
+{
+   "$schema": "https://repometric.github.io/linterhub/schema/args.json",
+   "name": "",
+   "type": "object",
+   "allOf": [
+      {
+         "$ref": "#/definitions/arguments"
+      }
+   ],
+   "delimiter": "=",
+   "definitions": {
+      "arguments": {
+         "type": "object",
+         "properties": {
+            "--ignore": {
+               "id": "--ignore",
+               "type": "string",
+               "description": "Additional paths to ignore [Can be set multiple times]",
+               "default": null
+            },
+            "--space": {
+               "id": "args:--space",
+               "type": "string",
+               "description": "Use space indent instead of tabs [Default: 2]",
+               "default": "2"
+            },
+            "--no-semicolon": {
+               "id": "--no-semicolon",
+               "type": "string",
+               "description": "Prevent use of semicolons",
+               "default": null
+            },
+            "--prettier": {
+               "id": "--prettier",
+               "type": "string",
+               "description": "Conform to Prettier code style",
+               "default": null
+            },
+            "--node-version": {
+               "id": "--node-version",
+               "type": "string",
+               "description": "Range of Node.js version to support",
+               "default": null
+            },
+            "--plugin": {
+               "id": "--plugin",
+               "type": "string",
+               "description": "Include third-party plugins [Can be set multiple times]",
+               "default": null
+            },
+            "--extend": {
+               "id": "--extend",
+               "type": "string",
+               "description": "Extend defaults with a custom config [Can be set multiple times]",
+               "default": null
+            },
+            "--open": {
+               "id": "--open",
+               "type": "string",
+               "description": "Open files with issues in your editor",
+               "default": null
+            },
+            "--quiet": {
+               "id": "--quiet",
+               "type": "string",
+               "description": "Show only errors and no warnings",
+               "default": null
+            },
+            "--extension": {
+               "id": "--extension",
+               "type": "string",
+               "description": "Additional extension to lint [Can be set multiple times]",
+               "default": null
+            },
+            "--no-esnext": {
+               "id": "--no-esnext",
+               "type": "string",
+               "description": "Don't enforce ES2015+ rules",
+               "default": null
+            },
+            "--cwd": {
+               "id": "args:--cwd",
+               "type": "string",
+               "description": "Working directory for files",
+               "default": null
+            },
+            "--stdin": {
+               "id": "linterhub:stdin",
+               "type": "string",
+               "description": "Validate/fix code from stdin",
+               "default": null
+            },
+            "--stdin-filename": {
+               "id": "linterhub:filename",
+               "type": "string",
+               "description": "Specify a filename for the --stdin option",
+               "default": null
+            },
+            "": {
+               "id": "linterhub:path",
+               "type": "string",
+               "description": "Path to file or folder to analyze",
+               "default": null
+            }
+         }
+      },
+      "section": {
+         "type": "object",
+         "description": "The engine configuration section",
+         "properties": {
+            "name": {
+               "type": "string",
+               "description": "The engine name",
+               "enum": ""
+            },
+            "options": {
+               "type": "object",
+               "description": "The engine configuration",
+               "$ref": "#/definitions/arguments"
+            }
+         }
+      }
+   }
+}

--- a/test/parsing/files/full.valid.txt
+++ b/test/parsing/files/full.valid.txt
@@ -1,0 +1,31 @@
+  JavaScript happiness style linter ❤️
+
+  Usage:
+    $ xo [<file|glob> ...]
+
+  Options:
+   --ignore           Additional paths to ignore   [Can be set multiple times]
+    --space           Use space indent instead of tabs [Default: 2]
+    --no-semicolon    Prevent use of semicolons
+    --prettier        Conform to Prettier code style
+    --node-version    Range of Node.js version to support
+    --plugin          Include third-party plugins [Can be set multiple times]
+    --extend          Extend defaults with a custom config [Can be set multiple times]
+    --open            Open files with issues in your editor
+    --quiet           Show only errors and no warnings
+    --extension       Additional extension to lint [Can be set multiple times]
+    --no-esnext       Don't enforce ES2015+ rules
+    --cwd=<dir>       Working directory for files
+    --stdin           Validate/fix code from stdin
+    --stdin-filename  Specify a filename for the --stdin option
+
+  Examples:
+    $ xo
+    $ xo index.js
+    $ xo *.js !foo.js
+    $ xo --space
+    $ xo --env=node --env=mocha
+    $ xo --init --space
+    $ xo --plugin=react
+    $ xo --plugin=html --extension=html
+    $ echo 'const x=true' | xo --stdin --fix

--- a/test/parsing/files/option.args.json
+++ b/test/parsing/files/option.args.json
@@ -1,0 +1,40 @@
+{
+   "$schema": "https://repometric.github.io/linterhub/schema/args.json",
+   "name": "",
+   "type": "object",
+   "allOf": [
+      {
+         "$ref": "#/definitions/arguments"
+      }
+   ],
+   "delimiter": "=",
+   "definitions": {
+      "arguments": {
+         "type": "object",
+         "properties": {
+            "--cwd": {
+               "id": "args:--cwd",
+               "type": "string",
+               "description": "Working directory for files",
+               "default": null
+            }
+         }
+      },
+      "section": {
+         "type": "object",
+         "description": "The engine configuration section",
+         "properties": {
+            "name": {
+               "type": "string",
+               "description": "The engine name",
+               "enum": ""
+            },
+            "options": {
+               "type": "object",
+               "description": "The engine configuration",
+               "$ref": "#/definitions/arguments"
+            }
+         }
+      }
+   }
+}

--- a/test/parsing/files/option.args.txt
+++ b/test/parsing/files/option.args.txt
@@ -1,0 +1,2 @@
+  Options:
+    --cwd <dir>       Working directory for files

--- a/test/parsing/files/option.default.json
+++ b/test/parsing/files/option.default.json
@@ -1,0 +1,40 @@
+{
+   "$schema": "https://repometric.github.io/linterhub/schema/args.json",
+   "name": "",
+   "type": "object",
+   "allOf": [
+      {
+         "$ref": "#/definitions/arguments"
+      }
+   ],
+   "delimiter": "=",
+   "definitions": {
+      "arguments": {
+         "type": "object",
+         "properties": {
+            "--space": {
+               "id": "args:--space",
+               "type": "string",
+               "description": "Use space indent instead of tabs [Default: 2]",
+               "default": "2"
+            }
+         }
+      },
+      "section": {
+         "type": "object",
+         "description": "The engine configuration section",
+         "properties": {
+            "name": {
+               "type": "string",
+               "description": "The engine name",
+               "enum": ""
+            },
+            "options": {
+               "type": "object",
+               "description": "The engine configuration",
+               "$ref": "#/definitions/arguments"
+            }
+         }
+      }
+   }
+}

--- a/test/parsing/files/option.default.txt
+++ b/test/parsing/files/option.default.txt
@@ -1,0 +1,2 @@
+  Options:
+    --space           Use space indent instead of tabs [Default: 2]

--- a/test/parsing/files/option.longname.json
+++ b/test/parsing/files/option.longname.json
@@ -1,0 +1,40 @@
+{
+   "$schema": "https://repometric.github.io/linterhub/schema/args.json",
+   "name": "",
+   "type": "object",
+   "allOf": [
+      {
+         "$ref": "#/definitions/arguments"
+      }
+   ],
+   "delimiter": "=",
+   "definitions": {
+      "arguments": {
+         "type": "object",
+         "properties": {
+            "--ignore": {
+               "id": "--ignore",
+               "type": "string",
+               "description": "Additional paths to ignore [Can be set multiple times]",
+               "default": null
+            }
+         }
+      },
+      "section": {
+         "type": "object",
+         "description": "The engine configuration section",
+         "properties": {
+            "name": {
+               "type": "string",
+               "description": "The engine name",
+               "enum": ""
+            },
+            "options": {
+               "type": "object",
+               "description": "The engine configuration",
+               "$ref": "#/definitions/arguments"
+            }
+         }
+      }
+   }
+}

--- a/test/parsing/files/option.longname.txt
+++ b/test/parsing/files/option.longname.txt
@@ -1,0 +1,2 @@
+  Options:
+  --ignore          Additional paths to ignore [Can be set multiple times]

--- a/test/parsing/files/option.multiline.json
+++ b/test/parsing/files/option.multiline.json
@@ -1,0 +1,40 @@
+{
+   "$schema": "https://repometric.github.io/linterhub/schema/args.json",
+   "name": "",
+   "type": "object",
+   "allOf": [
+      {
+         "$ref": "#/definitions/arguments"
+      }
+   ],
+   "delimiter": "=",
+   "definitions": {
+      "arguments": {
+         "type": "object",
+         "properties": {
+            "--ignore": {
+               "id": "--ignore",
+               "type": "string",
+               "description": "Additional paths to ignore",
+               "default": null
+            }
+         }
+      },
+      "section": {
+         "type": "object",
+         "description": "The engine configuration section",
+         "properties": {
+            "name": {
+               "type": "string",
+               "description": "The engine name",
+               "enum": ""
+            },
+            "options": {
+               "type": "object",
+               "description": "The engine configuration",
+               "$ref": "#/definitions/arguments"
+            }
+         }
+      }
+   }
+}

--- a/test/parsing/files/option.multiline.txt
+++ b/test/parsing/files/option.multiline.txt
@@ -1,0 +1,3 @@
+  Options:
+  -i, --ignore          Additional paths
+                       to ignore  [Can be set multiple times]

--- a/test/parsing/files/option.shortname.json
+++ b/test/parsing/files/option.shortname.json
@@ -1,0 +1,40 @@
+{
+   "$schema": "https://repometric.github.io/linterhub/schema/args.json",
+   "name": "",
+   "type": "object",
+   "allOf": [
+      {
+         "$ref": "#/definitions/arguments"
+      }
+   ],
+   "delimiter": "=",
+   "definitions": {
+      "arguments": {
+         "type": "object",
+         "properties": {
+            "-i": {
+               "id": "-i",
+               "type": "string",
+               "description": "Additional paths to ignore [Can be set multiple times]",
+               "default": null
+            }
+         }
+      },
+      "section": {
+         "type": "object",
+         "description": "The engine configuration section",
+         "properties": {
+            "name": {
+               "type": "string",
+               "description": "The engine name",
+               "enum": ""
+            },
+            "options": {
+               "type": "object",
+               "description": "The engine configuration",
+               "$ref": "#/definitions/arguments"
+            }
+         }
+      }
+   }
+}

--- a/test/parsing/files/option.shortname.txt
+++ b/test/parsing/files/option.shortname.txt
@@ -1,0 +1,2 @@
+  Options:
+  -i          Additional paths to ignore [Can be set multiple times]

--- a/test/parsing/files/option.simple.json
+++ b/test/parsing/files/option.simple.json
@@ -1,0 +1,40 @@
+{
+   "$schema": "https://repometric.github.io/linterhub/schema/args.json",
+   "name": "",
+   "type": "object",
+   "allOf": [
+      {
+         "$ref": "#/definitions/arguments"
+      }
+   ],
+   "delimiter": "=",
+   "definitions": {
+      "arguments": {
+         "type": "object",
+         "properties": {
+            "--ignore": {
+               "id": "--ignore",
+               "type": "string",
+               "description": "Additional paths to ignore [Can be set multiple times]",
+               "default": null
+            }
+         }
+      },
+      "section": {
+         "type": "object",
+         "description": "The engine configuration section",
+         "properties": {
+            "name": {
+               "type": "string",
+               "description": "The engine name",
+               "enum": ""
+            },
+            "options": {
+               "type": "object",
+               "description": "The engine configuration",
+               "$ref": "#/definitions/arguments"
+            }
+         }
+      }
+   }
+}

--- a/test/parsing/files/option.simple.txt
+++ b/test/parsing/files/option.simple.txt
@@ -1,0 +1,2 @@
+  Options:
+   --ignore, -i          Additional paths to ignore [Can be set multiple times]

--- a/test/parsing/files/usage.no-path.json
+++ b/test/parsing/files/usage.no-path.json
@@ -1,0 +1,40 @@
+{
+   "$schema": "https://repometric.github.io/linterhub/schema/args.json",
+   "name": "",
+   "type": "object",
+   "allOf": [
+      {
+         "$ref": "#/definitions/arguments"
+      }
+   ],
+   "delimiter": "=",
+   "definitions": {
+      "arguments": {
+         "type": "object",
+         "properties": {
+            "--ignore": {
+               "id": "--ignore",
+               "type": "string",
+               "description": "Additional paths to ignore [Can be set multiple times]",
+               "default": null
+            }
+         }
+      },
+      "section": {
+         "type": "object",
+         "description": "The engine configuration section",
+         "properties": {
+            "name": {
+               "type": "string",
+               "description": "The engine name",
+               "enum": ""
+            },
+            "options": {
+               "type": "object",
+               "description": "The engine configuration",
+               "$ref": "#/definitions/arguments"
+            }
+         }
+      }
+   }
+}

--- a/test/parsing/files/usage.no-path.txt
+++ b/test/parsing/files/usage.no-path.txt
@@ -1,0 +1,5 @@
+  Usage:
+    $ xo [<glob> ...]
+
+  Options:
+   --ignore, -i          Additional paths to ignore [Can be set multiple times]

--- a/test/parsing/files/usage.path.json
+++ b/test/parsing/files/usage.path.json
@@ -1,0 +1,46 @@
+{
+   "$schema": "https://repometric.github.io/linterhub/schema/args.json",
+   "name": "",
+   "type": "object",
+   "allOf": [
+      {
+         "$ref": "#/definitions/arguments"
+      }
+   ],
+   "delimiter": "=",
+   "definitions": {
+      "arguments": {
+         "type": "object",
+         "properties": {
+            "--ignore": {
+               "id": "--ignore",
+               "type": "string",
+               "description": "Additional paths to ignore [Can be set multiple times]",
+               "default": null
+            },
+            "": {
+               "id": "linterhub:path",
+               "type": "string",
+               "description": "Path to file or folder to analyze",
+               "default": null
+            }
+         }
+      },
+      "section": {
+         "type": "object",
+         "description": "The engine configuration section",
+         "properties": {
+            "name": {
+               "type": "string",
+               "description": "The engine name",
+               "enum": ""
+            },
+            "options": {
+               "type": "object",
+               "description": "The engine configuration",
+               "$ref": "#/definitions/arguments"
+            }
+         }
+      }
+   }
+}

--- a/test/parsing/files/usage.path.txt
+++ b/test/parsing/files/usage.path.txt
@@ -1,0 +1,5 @@
+  Usage:
+    $ xo [<file|glob> ...]
+
+  Options:
+   --ignore, -i          Additional paths to ignore [Can be set multiple times]

--- a/test/parsing/test.js
+++ b/test/parsing/test.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const parser = require('./../../src/parser.js');
+const testsData = require('./test.json');
+const config = require('./../../src/template/configDefault.json');
+const mocha = require('mocha');
+const assert = require('assert');
+
+const main = () => {
+    testsData.tests.forEach((test) => {
+        const doc = fs.readFileSync(test.$ref, 'utf8');
+        mocha.it(`test ${test.description}`, () => {
+            const result = JSON.stringify(parser(doc, config), '', '    ');
+            const result1 = JSON.stringify(require(test.result), '', '    ');
+            test.valid ? assert.equal(result, result1) :
+                assert.notEqual(result, test.result);
+        });
+    });
+};
+
+module.exports = main;

--- a/test/parsing/test.json
+++ b/test/parsing/test.json
@@ -1,0 +1,96 @@
+{
+    "description": "tests of parsing",
+    "tests": [
+        {
+            "description": "example have delimiter \"=\"",
+            "$ref": "./test/parsing/files/example.delimiter1.txt",
+            "result": "./files/example.delimiter1.json",
+            "valid": true,
+            "object": "result"
+        },
+        {
+            "description": "example have space delimiter",
+            "$ref": "./test/parsing/files/example.delimiter2.txt",
+            "result": "./files/example.delimiter2.json",
+            "valid": true,
+            "object": "result"
+        },
+        {
+            "description": "example have any other delimiter",
+            "$ref": "./test/parsing/files/example.delimiter3.txt",
+            "result": "./files/example.delimiter3.json",
+            "valid": false,
+            "object": "result"
+        },
+        {
+            "description": "example have no delimiters",
+            "$ref": "./test/parsing/files/example.no-delimiter.txt",
+            "result": "./files/example.no-delimiter.json",
+            "valid": true,
+            "object": "result"
+        },
+        {
+            "description": "full test",
+            "$ref": "./test/parsing/files/full.valid.txt",
+            "result": "./files/full.valid.json",
+            "valid": true,
+            "object": "result"
+        },
+        {
+            "description": "option with prefix args",
+            "$ref": "./test/parsing/files/option.args.txt",
+            "result": "./files/option.args.json",
+            "valid": true,
+            "object": "result"
+        },
+        {
+            "description": "option with default value",
+            "$ref": "./test/parsing/files/option.default.txt",
+            "result": "./files/option.default.json",
+            "valid": true,
+            "object": "result"
+        },
+        {
+            "description": "option with only long name",
+            "$ref": "./test/parsing/files/option.longname.txt",
+            "result": "./files/option.longname.json",
+            "valid": true,
+            "object": "result"
+        },
+        {
+            "description": "option with multiline description what have more than one space",
+            "$ref": "./test/parsing/files/option.multiline.txt",
+            "result": "./files/option.multiline.json",
+            "valid": true,
+            "object": "result"
+        },
+        {
+            "description": "option with only short name",
+            "$ref": "./test/parsing/files/option.shortname.txt",
+            "result": "./files/option.shortname.json",
+            "valid": true,
+            "object": "result"
+        },
+        {
+            "description": "simple option",
+            "$ref": "./test/parsing/files/option.simple.txt",
+            "result": "./files/option.simple.json",
+            "valid": true,
+            "object": "result"
+        },
+        {
+            "description": "usage haven't got path/file (no linterhub:path in result)",
+            "$ref": "./test/parsing/files/usage.no-path.txt",
+            "result": "./files/usage.no-path.json",
+            "valid": true,
+            "object": "result"
+        },
+        {
+            "description": "usage have path/file (adds linterhub:path to result)",
+            "$ref": "./test/parsing/files/usage.path.txt",
+            "result": "./files/usage.path.json",
+            "valid": true,
+            "object": "result"
+        }
+    ]
+}


### PR DESCRIPTION
Add 13 parsing tests:
- example have delimiter =
- example have space delimiter
- example have any other delimiter [invalid]
- example have no delimiters

- full test

- simple option
- option with prefix args
- option with default value
- option with only long name
- option with multiline description what have more than one space
- option with only short name

- usage haven't got path/file (no linterhub:path in result)
- usage have path/file (adds linterhub:path to result)

Closes #50