### PR TITLE
fix: using of default delimiter from config

### DIFF
--- a/src/handle.js
+++ b/src/handle.js
@@ -6,6 +6,7 @@ const context = require('./template/context.js');
 const handle = (help, config) => {
     try {
         context.options = [];
+        context.delimiter = config.delimiter;
         Object.keys(context.section).forEach((sectionName) => {
             let section = context.section[sectionName];
             let sectionTitle = config.section[sectionName].name;


### PR DESCRIPTION
If help haven't got delimiter, delimiter from config will be used

Closes #43