### PR TITLE
fix: parsing

### DIFF
--- a/src/configValidation.js
+++ b/src/configValidation.js
@@ -19,7 +19,8 @@ const schemaValidating = (config) => {
 
 const fillingWithDefaults = (defaults, config) => {
     Object.keys(defaults).forEach((key) => {
-        !config[key] ? config[key] = defaults[key] : '';
+        config[key] =
+            typeof(config[key]) !== 'undefined' ? config[key] : defaults[key];
          Object.keys(defaults[key])[0] !== '0'
              ? fillingWithDefaults(defaults[key], config[key]) : '';
     });

--- a/src/parseSection.js
+++ b/src/parseSection.js
@@ -59,7 +59,7 @@ const splitSection = (section) => {
                 result.push(str);
                 j++;
             } else if (j > 0) {
-                result[j - 1] = result[j - 1] + ' ' + str;
+                result[j - 1] = result[j - 1] + '  ' + str;
             }
         });
         return result;


### PR DESCRIPTION
Fixed 3 problems:
- when description is fully on next line with option, it is not parsing
- exception when postfix or names [config] is string (not an array)
- parseWhole always changing to default config value

Closes #82