### PR TITLE
feat: add CLI docs sending as stdin & path to file

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -5,17 +5,29 @@ const configDefault = require('./src/template/configDefault.json');
 const {execSync} = require('child_process');
 const version = require('./package.json').version;
 const program = require('commander');
+const fs = require('fs');
+
+const runParser = (doc, config) => {
+    console.log(JSON.stringify(parser(doc, config), null, 4));
+};
 
 program
     .version(version)
     .option(
         '-c, --config <config>',
         'Custom config in json format',
-        configDefault)
+        configDefault
+    )
     .option(
         '-d, --docs <docs>',
         'The help page content (pass without <binary> argument)',
-        undefined)
+        undefined
+    )
+    .option(
+        '-f, --file <file>',
+        'Path to a file with CLI docs',
+        undefined
+    )
     .arguments('<binary>')
     .action(function(binary) {
         program.docs = execSync(`${binary} --help`).toString();
@@ -24,8 +36,22 @@ program
         'Parse help page specifying binary as argument or content as option')
     .parse(process.argv);
 
-if (program.docs) {
-    console.log(JSON.stringify(parser(program.docs, program.config), null, 2));
+
+if (program.docs || program.file) {
+    runParser(program.docs ? program.docs :
+        fs.readFileSync(program.file, 'utf8'), program.config);
+} else if (process.stdin && !process.stdin.isTTY) {
+    let doc = '';
+    process.stdin.setEncoding('utf-8');
+
+    process.stdin.on('readable', () => {
+        let chunk;
+        while (chunk = process.stdin.read()) {
+            doc += chunk;
+        }
+    });
+
+    process.stdin.on('end', () => runParser(doc, program.config));
 } else {
     program.help();
 }


### PR DESCRIPTION
Add to binary:
- sending CLI docs as stdin
- sending CLI docs as path to file

Closes #46